### PR TITLE
[Feat] Add Dockerfile to dockerize the api-server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+# Build API-Server executable
+FROM golang:1.24-alpine AS builder
+
+WORKDIR /app
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+
+RUN CGO_ENABLED=0 GOOS=linux go build -o /app/api-server .
+
+# Create a minimal runtime image
+FROM alpine:latest
+
+WORKDIR /app
+
+COPY --from=builder /app/api-server .
+
+EXPOSE 8080
+
+CMD ["./api-server"]


### PR DESCRIPTION
# Description
This PR introduces a Dockerfile that lets you run the API-Server as a (OCI / Docker)Container.
# Follow Up

- Issue #1 