### PR TITLE
[BUG]: Re-upload error logging

### DIFF
--- a/api/artifact.go
+++ b/api/artifact.go
@@ -570,7 +570,7 @@ func (server *Server) uploadArtifactWithFile(
 	artifact, err := stream.CloseAndRecv()
 	if err != nil {
 		// Check if it's a gRPC AlreadyExists error
-		if st, ok := status.FromError(err); ok && st.Code() == codes.AlreadyExists {
+		if status.Code(err) == codes.AlreadyExists {
 			log.Warn().Err(err).Msg("Artifact already exists")
 
 			return PostArtifactUpload409JSONResponse{


### PR DESCRIPTION
## BEFORE STATE:
On re-upload a user is presented with a 500 Internal Server Error, the API-Server logs show

```sh
7:57AM DBG Sent artifact chunk host=<host> sent_bytes=231 service=api-server version=v0.6.0
7:57AM INF HTTP Request host=<host> ip=<ip> latency=278.280657 method=POST path=/artifact/upload service=api-server size=224 status=201 user_agent=bruno-runtime/2.14.2 version=v0.6.0
7:58AM DBG Authenticating user with BasicAuth host=<host> service=api-server user=<username> version=v0.6.0
7:58AM DBG Sent artifact chunk host=<host> sent_bytes=231 service=api-server version=v0.6.0
7:58AM ERR Failed to finalize artifact upload error="rpc error: code = AlreadyExists desc = Artifact already exists for storing artifact metadata" host=<host> service=api-server version=v0.6.0
7:58AM WRN HTTP Request host=<host> ip=<ip> latency=93.675282 method=POST path=/artifact/upload service=api-server size=-1 status=500 user_agent=bruno-runtime/2.14.2 version=v0.6.0
```

## STATE NOW:
On re-upload a user is presented with a 409 Already exists error and an error description: `An artifact already exists with this fully qualified name and version hash`